### PR TITLE
Add criteria type, new Criteria and Query for query construction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${org.projectlombok.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/microsoft/azure/spring/data/documentdb/core/query/CriteriaType.java
+++ b/src/main/java/com/microsoft/azure/spring/data/documentdb/core/query/CriteriaType.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.data.documentdb.core.query;
+
+public enum CriteriaType {
+    AND,
+    OR,
+    BETWEEN,
+    IS_EQUAL
+}

--- a/src/main/java/com/microsoft/azure/spring/data/documentdb/core/query/NewCriteria.java
+++ b/src/main/java/com/microsoft/azure/spring/data/documentdb/core/query/NewCriteria.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.data.documentdb.core.query;
+
+import lombok.Getter;
+import org.springframework.lang.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class NewCriteria {
+
+    private CriteriaType type;
+    private String subject;
+    private List<NewCriteria> criteriaList;
+    private List<Object> criteriaValues;
+
+    public NewCriteria(CriteriaType criteriaType) {
+        this.type = criteriaType;
+        this.criteriaList = new ArrayList<>();
+    }
+
+    public static NewCriteria getInstance(@NonNull String subject, CriteriaType type, @NonNull List<Object> values) {
+        final NewCriteria criteria = new NewCriteria(type);
+
+        criteria.subject = subject;
+        criteria.criteriaValues = values;
+
+        return criteria;
+    }
+
+    public static NewCriteria getAndInstance(@NonNull NewCriteria left, @NonNull NewCriteria right) {
+       final NewCriteria criteria = new NewCriteria(CriteriaType.AND);
+
+       criteria.criteriaList.add(left);
+       criteria.criteriaList.add(right);
+
+       return criteria;
+    }
+
+    public static NewCriteria getOrInstance(@NonNull NewCriteria left, @NonNull NewCriteria right) {
+        final NewCriteria criteria = new NewCriteria(CriteriaType.OR);
+
+        criteria.criteriaList.add(left);
+        criteria.criteriaList.add(right);
+
+        return criteria;
+    }
+}

--- a/src/main/java/com/microsoft/azure/spring/data/documentdb/core/query/NewQuery.java
+++ b/src/main/java/com/microsoft/azure/spring/data/documentdb/core/query/NewQuery.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.data.documentdb.core.query;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.lang.NonNull;
+
+@NoArgsConstructor
+public class NewQuery {
+
+    @Getter
+    private Criteria criteria;
+
+    public NewQuery(@NonNull Criteria criteria) {
+        this.criteria = criteria;
+    }
+}
+
+


### PR DESCRIPTION
* As Criteria/Query is refenerced many times, add new here.

* If rest component of query construction ready, it will replace the old one.

* Add one enum type for criteria.

Signed-off-by: Pan Li <panli@microsoft.com>