### PR TITLE
Use one char as testdb suffix, fix #205.

### DIFF
--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/common/TestConstants.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/common/TestConstants.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestConstants {
-    private static final int SUFFIX_LENGTH = 3;
+    private static final int SUFFIX_LENGTH = 1;
     private static final String DB_NAME_SUFFIX = UUID.randomUUID().toString().substring(0, SUFFIX_LENGTH);
 
     private static final Address ADDRESS_1 = new Address("201107", "Zixing Road", "Shanghai");


### PR DESCRIPTION
* Comosdb limited the db acount 100 with one collection.

Signed-off-by: Pan Li <panli@microsoft.com>