### PR TITLE
Issue #253: swapping expected and actual in test cases where expectations had been reversed

### DIFF
--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/AddressRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/AddressRepositoryIT.java
@@ -97,7 +97,7 @@ public class AddressRepositoryIT {
         reference.sort(Comparator.comparing(Address::getPostalCode));
 
         Assert.assertEquals(result.size(), reference.size());
-        Assert.assertEquals(result, reference);
+        Assert.assertEquals(reference, result);
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/CustomerRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/CustomerRepositoryIT.java
@@ -62,12 +62,12 @@ public class CustomerRepositoryIT {
     }
 
     private void assertCustomerListEquals(@NonNull List<Customer> customers, @NonNull List<Customer> reference) {
-        Assert.assertEquals(customers.size(), reference.size());
+        Assert.assertEquals(reference.size(), customers.size());
 
         customers.sort(Comparator.comparing(Customer::getId));
         reference.sort(Comparator.comparing(Customer::getId));
 
-        Assert.assertEquals(customers, reference);
+        Assert.assertEquals(reference, customers);
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/IntegerIdDomainRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/IntegerIdDomainRepositoryIT.java
@@ -54,8 +54,8 @@ public class IntegerIdDomainRepositoryIT {
         final Optional<IntegerIdDomain> foundOptional = this.repository.findById(ID);
 
         Assert.assertTrue(foundOptional.isPresent());
-        Assert.assertEquals(foundOptional.get().getNumber(), DOMAIN.getNumber());
-        Assert.assertEquals(foundOptional.get().getName(), DOMAIN.getName());
+        Assert.assertEquals(DOMAIN.getNumber(), foundOptional.get().getNumber());
+        Assert.assertEquals(DOMAIN.getName(), foundOptional.get().getName());
 
         this.repository.delete(DOMAIN);
 

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/MemoRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/MemoRepositoryIT.java
@@ -114,8 +114,8 @@ public class MemoRepositoryIT {
         memos.sort(Comparator.comparing(Memo::getId));
         reference.sort(Comparator.comparing(Memo::getId));
 
-        Assert.assertEquals(memos.size(), reference.size());
-        Assert.assertEquals(memos, reference);
+        Assert.assertEquals(reference.size(), memos.size());
+        Assert.assertEquals(reference, memos);
     }
 
     @Test
@@ -126,8 +126,8 @@ public class MemoRepositoryIT {
 
         memos = this.repository.findByDateBeforeAndMessage(memoDate, TestConstants.MESSAGE);
 
-        Assert.assertEquals(memos.size(), 1);
-        Assert.assertEquals(memos.get(0), testMemo1);
+        Assert.assertEquals(1, memos.size());
+        Assert.assertEquals(testMemo1, memos.get(0));
 
         memos = this.repository.findByDateBeforeOrMessage(memoDateAfter, TestConstants.MESSAGE);
         final List<Memo> reference = Arrays.asList(testMemo1, testMemo2);
@@ -135,8 +135,8 @@ public class MemoRepositoryIT {
         memos.sort(Comparator.comparing(Memo::getId));
         reference.sort(Comparator.comparing(Memo::getId));
 
-        Assert.assertEquals(memos.size(), reference.size());
-        Assert.assertEquals(memos, reference);
+        Assert.assertEquals(reference.size(), memos.size());
+        Assert.assertEquals(reference, memos);
     }
 
     @Test
@@ -147,8 +147,8 @@ public class MemoRepositoryIT {
 
         memos = this.repository.findByDateAfter(memoDate);
 
-        Assert.assertEquals(memos.size(), 1);
-        Assert.assertEquals(memos.get(0), testMemo3);
+        Assert.assertEquals(1, memos.size());
+        Assert.assertEquals(testMemo3, memos.get(0));
 
         memos = this.repository.findByDateAfter(memoDateBefore);
         final List<Memo> reference = Arrays.asList(testMemo2, testMemo3);
@@ -156,8 +156,8 @@ public class MemoRepositoryIT {
         memos.sort(Comparator.comparing(Memo::getId));
         reference.sort(Comparator.comparing(Memo::getId));
 
-        Assert.assertEquals(memos.size(), reference.size());
-        Assert.assertEquals(memos, reference);
+        Assert.assertEquals(reference.size(), memos.size());
+        Assert.assertEquals(reference, memos);
     }
 
     @Test
@@ -168,8 +168,8 @@ public class MemoRepositoryIT {
 
         memos = this.repository.findByDateAfterAndMessage(memoDate, TestConstants.NEW_MESSAGE);
 
-        Assert.assertEquals(memos.size(), 1);
-        Assert.assertEquals(memos.get(0), testMemo3);
+        Assert.assertEquals(1, memos.size());
+        Assert.assertEquals(testMemo3, memos.get(0));
 
         memos = this.repository.findByDateAfterOrMessage(memoDateBefore, TestConstants.MESSAGE);
         final List<Memo> reference = Arrays.asList(testMemo1, testMemo2, testMemo3);
@@ -177,8 +177,8 @@ public class MemoRepositoryIT {
         memos.sort(Comparator.comparing(Memo::getId));
         reference.sort(Comparator.comparing(Memo::getId));
 
-        Assert.assertEquals(memos.size(), reference.size());
-        Assert.assertEquals(memos, reference);
+        Assert.assertEquals(reference.size(), memos.size());
+        Assert.assertEquals(reference, memos);
     }
 
     @Test
@@ -218,8 +218,8 @@ public class MemoRepositoryIT {
         memos.sort(Comparator.comparing(Memo::getId));
         reference.sort(Comparator.comparing(Memo::getId));
 
-        Assert.assertEquals(memos.size(), reference.size());
-        Assert.assertEquals(memos, reference);
+        Assert.assertEquals(reference.size(), memos.size());
+        Assert.assertEquals(reference, memos);
     }
 
     @Test(expected = IllegalQueryException.class)

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositoryIT.java
@@ -81,12 +81,12 @@ public class ProjectRepositoryIT {
     }
 
     private void assertProjectListEquals(@NonNull List<Project> projects, @NonNull List<Project> reference) {
-        Assert.assertEquals(projects.size(), reference.size());
+        Assert.assertEquals(reference.size(), projects.size());
 
         projects.sort(Comparator.comparing(Project::getId));
         reference.sort(Comparator.comparing(Project::getId));
 
-        Assert.assertEquals(projects, reference);
+        Assert.assertEquals(reference, projects);
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositorySortIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositorySortIT.java
@@ -86,8 +86,8 @@ public class ProjectRepositorySortIT {
 
         PROJECTS.sort(Comparator.comparing(Project::getStarCount));
 
-        Assert.assertEquals(projects.size(), PROJECTS.size());
-        Assert.assertEquals(projects, PROJECTS);
+        Assert.assertEquals(PROJECTS.size(), projects.size());
+        Assert.assertEquals(PROJECTS, projects);
     }
 
     @Test
@@ -97,8 +97,8 @@ public class ProjectRepositorySortIT {
 
         PROJECTS.sort(Comparator.comparing(Project::getCreator).reversed());
 
-        Assert.assertEquals(projects.size(), PROJECTS.size());
-        Assert.assertEquals(projects, PROJECTS);
+        Assert.assertEquals(PROJECTS.size(), projects.size());
+        Assert.assertEquals(PROJECTS, projects);
     }
 
     @Test
@@ -109,8 +109,8 @@ public class ProjectRepositorySortIT {
         PROJECTS.sort(Comparator.comparing(Project::getId));
         projects.sort(Comparator.comparing(Project::getId));
 
-        Assert.assertEquals(projects.size(), PROJECTS.size());
-        Assert.assertEquals(projects, PROJECTS);
+        Assert.assertEquals(PROJECTS.size(), projects.size());
+        Assert.assertEquals(PROJECTS, projects);
     }
 
     @Test(expected = IllegalQueryException.class)
@@ -150,8 +150,8 @@ public class ProjectRepositorySortIT {
 
         references.sort(Comparator.comparing(Project::getStarCount));
 
-        Assert.assertEquals(projects.size(), references.size());
-        Assert.assertEquals(projects, references);
+        Assert.assertEquals(references.size(), projects.size());
+        Assert.assertEquals(references, projects);
     }
 
     @Test
@@ -162,8 +162,8 @@ public class ProjectRepositorySortIT {
 
         references.sort(Comparator.comparing(Project::getStarCount));
 
-        Assert.assertEquals(projects.size(), references.size());
-        Assert.assertEquals(projects, references);
+        Assert.assertEquals(references.size(), projects.size());
+        Assert.assertEquals(references, projects);
     }
 
     @Test
@@ -174,8 +174,8 @@ public class ProjectRepositorySortIT {
 
         references.sort(Comparator.comparing(Project::getName).reversed());
 
-        Assert.assertEquals(projects.size(), references.size());
-        Assert.assertEquals(projects, references);
+        Assert.assertEquals(references.size(), projects.size());
+        Assert.assertEquals(references, projects);
     }
 }
 

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/QuestionRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/QuestionRepositoryIT.java
@@ -55,7 +55,7 @@ public class QuestionRepositoryIT {
         final Optional<Question> optional = this.repository.findById(QUESTION_ID);
 
         Assert.assertTrue(optional.isPresent());
-        Assert.assertEquals(optional.get(), QUESTION);
+        Assert.assertEquals(QUESTION, optional.get());
     }
 
     @Test(expected = DocumentDBAccessException.class)
@@ -67,7 +67,7 @@ public class QuestionRepositoryIT {
     public void testFindAll() {
         final List<Question> questions = Lists.newArrayList(this.repository.findAll());
 
-        Assert.assertEquals(questions, Collections.singletonList(QUESTION));
+        Assert.assertEquals(Collections.singletonList(QUESTION), questions);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class QuestionRepositoryIT {
         Optional<Question> optional = this.repository.findById(QUESTION_ID);
 
         Assert.assertTrue(optional.isPresent());
-        Assert.assertEquals(optional.get(), QUESTION);
+        Assert.assertEquals(QUESTION, optional.get());
 
         this.repository.delete(QUESTION);
         optional = this.repository.findById(QUESTION_ID);

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/StudentRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/StudentRepositoryIT.java
@@ -136,7 +136,7 @@ public class StudentRepositoryIT {
         people.sort(Comparator.comparing(Student::getId));
         reference.sort(Comparator.comparing(Student::getId));
 
-        Assert.assertEquals(people, reference);
+        Assert.assertEquals(reference, people);
     }
 
     @Test


### PR DESCRIPTION
Impacts only the ordering of the expected vs. actual in the tests within the `com.microsoft.azure.spring.data.cosmosdb.repository.integration` package (the original issue called out one specific test in that package, but I found a handful of others with what appeared to be the same issue... let me know if there are other places where I can address this, as well).