### PR TITLE
Rename snapshot version to be picked up by shields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>spring-data-cosmosdb</artifactId>
-    <version>2.1.2.BUILD-SNAPSHOT</version>
+    <version>2.1.2-SNAPSHOT</version>
 
     <name>Spring Data for Azure Cosmos DB SQL API</name>
     <description>Spring Data for Azure Cosmos DB SQL API</description>


### PR DESCRIPTION
The https://img.shields.io will return `invalid response data` when the version format is `x.y.z.BUILD-SNAPSHOT`.  https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8905