### PR TITLE
Remove 'final' access modifier from variable

### DIFF
--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/DocumentDbFactory.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/DocumentDbFactory.java
@@ -44,8 +44,8 @@ public class DocumentDbFactory {
     }
 
     public DocumentClient getDocumentClient() {
-        final ConnectionPolicy policy = config.getConnectionPolicy();
-        final String userAgent = getUserAgentSuffix() + ";" + policy.getUserAgentSuffix();
+        ConnectionPolicy policy = config.getConnectionPolicy();
+        String userAgent = getUserAgentSuffix() + ";" + policy.getUserAgentSuffix();
 
         policy.setUserAgentSuffix(userAgent);
 


### PR DESCRIPTION
Hello Dear, Microsoft Developers!

I have removed the 'final' access modifier from the variable because they are not necessary.

Yours sincerely,
Manuel Kollus