### PR TITLE
Custom partition key name

### DIFF
--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/PartitionKey.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/PartitionKey.java
@@ -11,4 +11,11 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})
 public @interface PartitionKey {
+
+	/**
+	 * The name of the partition key if the serialized attribute name differs from the field name
+	 *
+	 * @return
+	 */
+	String value() default "";
 }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/PartitionKey.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/PartitionKey.java
@@ -12,10 +12,10 @@ import java.lang.annotation.*;
 @Target({ElementType.FIELD})
 public @interface PartitionKey {
 
-	/**
-	 * The name of the partition key if the serialized attribute name differs from the field name
-	 *
-	 * @return
-	 */
-	String value() default "";
+    /**
+     * The name of the partition key if the serialized attribute name differs from the field name
+     *
+     * @return
+     */
+    String value() default "";
 }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformation.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformation.java
@@ -84,7 +84,12 @@ public class DocumentDbEntityInformation<T, ID> extends AbstractEntityInformatio
     }
 
     public String getPartitionKeyFieldName() {
-        return partitionKeyField == null ? null : partitionKeyField.getName();
+        if (partitionKeyField == null) {
+            return null;
+        } else {
+            PartitionKey partitionKey = partitionKeyField.getAnnotation(PartitionKey.class);
+            return partitionKey.value().equals("") ? partitionKeyField.getName() : partitionKey.value();
+        }
     }
 
     public String getPartitionKeyFieldValue(T entity) {

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformation.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformation.java
@@ -87,7 +87,7 @@ public class DocumentDbEntityInformation<T, ID> extends AbstractEntityInformatio
         if (partitionKeyField == null) {
             return null;
         } else {
-            PartitionKey partitionKey = partitionKeyField.getAnnotation(PartitionKey.class);
+            final PartitionKey partitionKey = partitionKeyField.getAnnotation(PartitionKey.class);
             return partitionKey.value().equals("") ? partitionKeyField.getName() : partitionKey.value();
         }
     }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformationUnitTest.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformationUnitTest.java
@@ -99,6 +99,22 @@ public class DocumentDbEntityInformationUnitTest {
         private String id;
         @PartitionKey("vol_name")
         private String name;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 
     @Document
@@ -106,5 +122,21 @@ public class DocumentDbEntityInformationUnitTest {
         private String id;
         @PartitionKey
         private String name;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformationUnitTest.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformationUnitTest.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.spring.data.cosmosdb.repository.support;
 
 import com.microsoft.azure.spring.data.cosmosdb.common.TestConstants;
 import com.microsoft.azure.spring.data.cosmosdb.core.mapping.Document;
+import com.microsoft.azure.spring.data.cosmosdb.core.mapping.PartitionKey;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Address;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Person;
 import org.junit.Test;
@@ -60,9 +61,50 @@ public class DocumentDbEntityInformationUnitTest {
         assertThat(collectionName).isEqualTo("testCollection");
     }
 
+    @Test
+    public void testGetPartitionKeyName() {
+        final DocumentDbEntityInformation<VolunteerWithPartitionKey, String> entityInformation =
+                new DocumentDbEntityInformation<>(VolunteerWithPartitionKey.class);
+
+        final String partitionKeyName = entityInformation.getPartitionKeyFieldName();
+        assertThat(partitionKeyName).isEqualTo("name");
+    }
+
+    @Test
+    public void testNullPartitionKeyName() {
+        final DocumentDbEntityInformation<Volunteer, String> entityInformation =
+                new DocumentDbEntityInformation<>(Volunteer.class);
+
+        final String partitionKeyName = entityInformation.getPartitionKeyFieldName();
+        assertThat(partitionKeyName).isEqualTo(null);
+    }
+
+    @Test
+    public void testCustomPartitionKeyName() {
+        final DocumentDbEntityInformation<VolunteerWithCustomPartitionKey, String> entityInformation =
+                new DocumentDbEntityInformation<>(VolunteerWithCustomPartitionKey.class);
+
+        final String partitionKeyName = entityInformation.getPartitionKeyFieldName();
+        assertThat(partitionKeyName).isEqualTo("vol_name");
+    }
+
     @Document(collection = "testCollection")
     class Volunteer {
         String id;
+        String name;
+    }
+
+    @Document
+    class VolunteerWithCustomPartitionKey {
+        String id;
+        @PartitionKey("vol_name")
+        String name;
+    }
+
+    @Document
+    class VolunteerWithPartitionKey {
+        String id;
+        @PartitionKey
         String name;
     }
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformationUnitTest.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformationUnitTest.java
@@ -95,16 +95,16 @@ public class DocumentDbEntityInformationUnitTest {
     }
 
     @Document
-    class VolunteerWithCustomPartitionKey {
-        String id;
+    private class VolunteerWithCustomPartitionKey {
+        private String id;
         @PartitionKey("vol_name")
-        String name;
+        private String name;
     }
 
     @Document
-    class VolunteerWithPartitionKey {
-        String id;
+    private class VolunteerWithPartitionKey {
+        private String id;
         @PartitionKey
-        String name;
+        private String name;
     }
 }


### PR DESCRIPTION
I use snake case for json serialization, but the @PartitionKey annotation only uses the java field name. This PR addresses that mismatch.

```
@PartitionKey("partition_key")
String partitionKey;
```