### PR TITLE
Cosmos key credential support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -17,6 +17,7 @@
         </exec>
         <propertyfile file="./src/test/resources/application.properties">
             <entry key="cosmosdb.key" value="${cosmosdb.key}"/>
+            <entry key="cosmosdb.secondaryKey" value="${cosmosdb.secondaryKey}"/>
             <entry key="cosmosdb.uri" value="https://${azure.test.dbname}.documents.azure.com:443"/>
         </propertyfile>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -7,14 +7,18 @@
             <arg value=".\src\libs\setup.bat"/>
             <arg value="${azure.test.resourcegroup}"/>
             <arg value="${azure.test.dbname}"/>
-            <redirector outputproperty="cosmosdb.key"/>
+            <redirector outputproperty="cosmosdb.keys"/>
         </exec>
         <exec osfamily="unix" executable="bash">
             <arg value="./src/libs/setup.sh"/>
             <arg value="${azure.test.resourcegroup}"/>
             <arg value="${azure.test.dbname}"/>
-            <redirector outputproperty="cosmosdb.key"/>
+            <redirector outputproperty="cosmosdb.keys"/>
         </exec>
+        <script language="javascript">
+            project.setProperty('cosmosdb.key', project.getProperty('cosmosdb.keys').split(' ')[0]);
+            project.setProperty('cosmosdb.secondaryKey', project.getProperty('cosmosdb.keys').split(' ')[1]);
+        </script>
         <propertyfile file="./src/test/resources/application.properties">
             <entry key="cosmosdb.key" value="${cosmosdb.key}"/>
             <entry key="cosmosdb.secondaryKey" value="${cosmosdb.secondaryKey}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <project.reactor.test.version>3.2.5.RELEASE</project.reactor.test.version>
 
         <azure.documentdb.version>1.16.2</azure.documentdb.version>
-        <azure.cosmos.version>3.0.0</azure.cosmos.version>
+        <azure.cosmos.version>3.1.0</azure.cosmos.version>
         <azure.test.resourcegroup>spring-data-cosmosdb-test</azure.test.resourcegroup>
         <azure.test.dbname>testdb-${maven.build.timestamp}</azure.test.dbname>
         <skip.integration.tests>true</skip.integration.tests>

--- a/samplecode/example/src/main/resources/application.properties
+++ b/samplecode/example/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 azure.cosmosdb.uri=your-cosmosDb-uri
 azure.cosmosdb.key=your-cosmosDb-key
+azure.cosmosdb.secondaryKey=your-cosmosDb-secondary-key
 azure.cosmosdb.database=your-cosmosDb-dbName

--- a/samplecode/example/src/test/resources/application.properties
+++ b/samplecode/example/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 azure.cosmosdb.uri=your-cosmosDb-uri
 azure.cosmosdb.key=your-cosmosDb-key
+azure.cosmosdb.secondaryKey=your-cosmosDb-secondary-key
 azure.cosmosdb.database=your-cosmosDb-dbName

--- a/src/libs/setup.sh
+++ b/src/libs/setup.sh
@@ -16,6 +16,7 @@ fi
 az login --service-principal -u $CLIENT_ID -p $CLIENT_KEY --tenant $TENANT_ID >> tmp.txt
 az group create -l westus -n $resourcegroup 2>1 > /dev/null
 cosmosDbUri=$(az cosmosdb create --name $dbname --resource-group $resourcegroup --kind GlobalDocumentDB --query documentEndpoint)
-cosmosDbKey=$(az cosmosdb keys list --name $dbname --resource-group $resourcegroup --query primaryMasterKey)
+cosmosDbPrimaryKey=$(az cosmosdb keys list --name $dbname --resource-group $resourcegroup --query primaryMasterKey)
+cosmosDbSecondaryKey=$(az cosmosdb keys list --name $dbname --resource-group $resourcegroup --query secondaryMasterKey)
 
-echo $cosmosDbKey | sed -e 's/^"//' -e 's/"$//'
+echo "$cosmosDbPrimaryKey $cosmosDbSecondaryKey" | sed -e 's/"//g'

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactory.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactory.java
@@ -15,6 +15,7 @@ import com.microsoft.azure.spring.data.cosmosdb.config.DocumentDBConfig;
 import lombok.Getter;
 import lombok.NonNull;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 
@@ -49,14 +50,20 @@ public class CosmosDbFactory {
 
         policy.setUserAgentSuffix(userAgent);
         return CosmosClient.builder()
-                .endpoint(config.getUri())
-                .key(config.getKey())
-                .build();
+                           .endpoint(config.getUri())
+                           .key(config.getKey())
+                           .cosmosKeyCredential(config.getCosmosKeyCredential())
+                           .build();
     }
 
     private void validateConfig(@NonNull DocumentDBConfig config) {
         Assert.hasText(config.getUri(), "cosmosdb host url should have text!");
-        Assert.hasText(config.getKey(), "cosmosdb host key should have text!");
+        if (config.getCosmosKeyCredential() == null) {
+            Assert.hasText(config.getKey(), "cosmosdb host key should have text!");
+        } else if (StringUtils.isEmpty(config.getKey())) {
+            Assert.hasText(config.getCosmosKeyCredential().key(),
+                "cosmosdb credential host key should have text!");
+        }
         Assert.hasText(config.getDatabase(), "cosmosdb database should have text!");
         Assert.notNull(config.getConnectionPolicy(), "cosmosdb connection policy should not be null!");
     }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/DocumentDBConfig.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/DocumentDBConfig.java
@@ -5,6 +5,7 @@
  */
 package com.microsoft.azure.spring.data.cosmosdb.config;
 
+import com.azure.data.cosmos.CosmosKeyCredential;
 import com.microsoft.azure.documentdb.ConnectionPolicy;
 import com.microsoft.azure.documentdb.ConsistencyLevel;
 import com.microsoft.azure.documentdb.RequestOptions;
@@ -29,6 +30,19 @@ public class DocumentDBConfig {
     private boolean allowTelemetry;
 
     private RequestOptions requestOptions;
+
+    private CosmosKeyCredential cosmosKeyCredential;
+
+    public static DocumentDBConfigBuilder builder(String uri, CosmosKeyCredential cosmosKeyCredential,
+                                                  String database) {
+        return defaultBuilder()
+            .uri(uri)
+            .cosmosKeyCredential(cosmosKeyCredential)
+            .database(database)
+            .connectionPolicy(ConnectionPolicy.GetDefault())
+            .consistencyLevel(ConsistencyLevel.Session)
+            .requestOptions(new RequestOptions());
+    }
 
     public static DocumentDBConfigBuilder builder(String uri, String key, String database) {
         return defaultBuilder()

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplate.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplate.java
@@ -23,6 +23,7 @@ import com.microsoft.azure.spring.data.cosmosdb.core.query.CriteriaType;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import com.microsoft.azure.spring.data.cosmosdb.exception.DocumentDBAccessException;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.DocumentDbEntityInformation;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
@@ -47,6 +48,7 @@ public class ReactiveCosmosTemplate implements ReactiveCosmosOperations, Applica
 
     private final String databaseName;
 
+    @Getter(AccessLevel.PRIVATE)
     private final CosmosClient cosmosClient;
 
     private final List<String> collectionCache;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplate.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplate.java
@@ -23,7 +23,6 @@ import com.microsoft.azure.spring.data.cosmosdb.core.query.CriteriaType;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import com.microsoft.azure.spring.data.cosmosdb.exception.DocumentDBAccessException;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.DocumentDbEntityInformation;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
@@ -48,7 +47,7 @@ public class ReactiveCosmosTemplate implements ReactiveCosmosOperations, Applica
 
     private final String databaseName;
 
-    @Getter(AccessLevel.PRIVATE)
+    @Getter
     private final CosmosClient cosmosClient;
 
     private final List<String> collectionCache;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplate.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplate.java
@@ -47,7 +47,6 @@ public class ReactiveCosmosTemplate implements ReactiveCosmosOperations, Applica
 
     private final String databaseName;
 
-    @Getter
     private final CosmosClient cosmosClient;
 
     private final List<String> collectionCache;

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/DocumentDbFactoryUnitTest.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/DocumentDbFactoryUnitTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DocumentDbFactoryUnitTest {
 
     @Test(expected = IllegalArgumentException.class)
-    public void testNullKey() {
-        final DocumentDBConfig dbConfig = DocumentDBConfig.builder(DOCUMENTDB_FAKE_HOST, null, DB_NAME).build();
+    public void testEmptyKey() {
+        final DocumentDBConfig dbConfig = DocumentDBConfig.builder(DOCUMENTDB_FAKE_HOST, "", DB_NAME).build();
         new DocumentDbFactory(dbConfig);
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 cosmosdb.uri=${DOCUMENTDB_URI}
 cosmosdb.key=${DOCUMENTDB_KEY}
+cosmosdb.secondaryKey=${COSMOSDB_SECONDARY_KEY}
 
 #You can also use connection string instead of uri and key to connect to cosmos DB
 #cosmosdb.connection-string=${DOCUMENTDB_CONNECTION_STRING}


### PR DESCRIPTION
* Added Cosmos Key Credential support to CosmosDBFactory. 
* Users can use single instance of CosmosKeyCredential to pass cosmos db account key to the DocumentDbConfig. 
* To rotate keys, user just need to update the key in CosmosKeyCredential instance, and Cosmos DB SDK will start using new key for the future requests. 