### PR TITLE
Added deprecation of DocumentDbAPIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <gson.version>2.8.4</gson.version>
         <project.reactor.test.version>3.3.0.RELEASE</project.reactor.test.version>
 
-        <azure.documentdb.version>2.4.2</azure.documentdb.version>
-        <azure.cosmos.version>3.3.0</azure.cosmos.version>
+        <azure.documentdb.version>1.16.2</azure.documentdb.version>
+        <azure.cosmos.version>3.1.0</azure.cosmos.version>
         <azure.test.resourcegroup>spring-data-cosmosdb-test</azure.test.resourcegroup>
         <azure.test.dbname>testdb-${maven.build.timestamp}</azure.test.dbname>
         <skip.integration.tests>true</skip.integration.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <gson.version>2.8.4</gson.version>
         <project.reactor.test.version>3.2.5.RELEASE</project.reactor.test.version>
 
-        <azure.documentdb.version>1.16.2</azure.documentdb.version>
+        <azure.documentdb.version>2.4.2</azure.documentdb.version>
         <azure.cosmos.version>3.1.0</azure.cosmos.version>
         <azure.test.resourcegroup>spring-data-cosmosdb-test</azure.test.resourcegroup>
         <azure.test.dbname>testdb-${maven.build.timestamp}</azure.test.dbname>

--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,10 @@
         <java.tuples.version>1.2</java.tuples.version>
         <slf4j.version>1.7.25</slf4j.version>
         <gson.version>2.8.4</gson.version>
-        <project.reactor.test.version>3.2.5.RELEASE</project.reactor.test.version>
+        <project.reactor.test.version>3.3.0.RELEASE</project.reactor.test.version>
 
         <azure.documentdb.version>2.4.2</azure.documentdb.version>
-        <azure.cosmos.version>3.1.0</azure.cosmos.version>
+        <azure.cosmos.version>3.3.0</azure.cosmos.version>
         <azure.test.resourcegroup>spring-data-cosmosdb-test</azure.test.resourcegroup>
         <azure.test.dbname>testdb-${maven.build.timestamp}</azure.test.dbname>
         <skip.integration.tests>true</skip.integration.tests>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <java.tuples.version>1.2</java.tuples.version>
         <slf4j.version>1.7.25</slf4j.version>
         <gson.version>2.8.4</gson.version>
-        <project.reactor.test.version>3.3.0.RELEASE</project.reactor.test.version>
+        <project.reactor.test.version>3.2.5.RELEASE</project.reactor.test.version>
 
         <azure.documentdb.version>1.16.2</azure.documentdb.version>
         <azure.cosmos.version>3.1.0</azure.cosmos.version>

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/Constants.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/Constants.java
@@ -30,5 +30,7 @@ public class Constants {
     public static final String OBJECTMAPPER_BEAN_NAME = "cosmosdbObjectMapper";
 
     public static final String ISO_8601_COMPATIBLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+    public static final String AZURE_COSMOS_DIRECT_MODE_PROTOCOL_PROPERTY = "azure.cosmos.directModeProtocol";
 }
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/Constants.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/Constants.java
@@ -30,7 +30,5 @@ public class Constants {
     public static final String OBJECTMAPPER_BEAN_NAME = "cosmosdbObjectMapper";
 
     public static final String ISO_8601_COMPATIBLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-
-    public static final String AZURE_COSMOS_DIRECT_MODE_PROTOCOL_PROPERTY = "azure.cosmos.directModeProtocol";
 }
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/Constants.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/Constants.java
@@ -29,6 +29,6 @@ public class Constants {
 
     public static final String OBJECTMAPPER_BEAN_NAME = "cosmosdbObjectMapper";
 
-    public static final String ISO_8601_COMPATIBLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:s:SSSXXX";
+    public static final String ISO_8601_COMPATIBLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 }
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactory.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactory.java
@@ -60,9 +60,6 @@ public class CosmosDbFactory {
                                             .toUpperCase(Locale.getDefault());
         }
 
-        //  Setting Direct Mode Protocol as Https
-        //  There is some version issue with Tcp protocol
-        System.setProperty(Constants.AZURE_COSMOS_DIRECT_MODE_PROTOCOL_PROPERTY, "Https");
         return CosmosClient.builder()
                            .endpoint(config.getUri())
                            .key(config.getKey())

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactory.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactory.java
@@ -52,7 +52,6 @@ public class CosmosDbFactory {
         final String userAgent = getUserAgentSuffix() + ";" + config.getConnectionPolicy().getUserAgentSuffix();
 
         policy.userAgentSuffix(userAgent);
-        policy.connectionMode(ConnectionMode.DIRECT);
 
         String consistencyLevelString = null;
         if (config.getConsistencyLevel() != null) {

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/DocumentDbFactory.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/DocumentDbFactory.java
@@ -19,6 +19,11 @@ import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 
+/**
+ * {@link DocumentDbFactory} is deprecated.
+ * Instead use {@link CosmosDbFactory}
+ */
+@Deprecated
 public class DocumentDbFactory {
 
     @Getter

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/AbstractDocumentDbConfiguration.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/AbstractDocumentDbConfiguration.java
@@ -19,6 +19,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * {@link AbstractDocumentDbConfiguration} is deprecated.
+ * Instead use AbstractCosmosConfiguration, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 @Configuration
 public abstract class AbstractDocumentDbConfiguration extends DocumentDbConfigurationSupport {
     @Bean

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/DocumentDBConfig.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/DocumentDBConfig.java
@@ -13,7 +13,11 @@ import com.microsoft.azure.spring.data.cosmosdb.exception.DocumentDBAccessExcept
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.util.Assert;
-
+/**
+ * {@link DocumentDBConfig} is deprecated.
+ * Instead use CosmosDBConfig, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 @Getter
 @Builder(builderMethodName = "defaultBuilder")
 public class DocumentDBConfig {

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/DocumentDbConfigurationSupport.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/config/DocumentDbConfigurationSupport.java
@@ -29,7 +29,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
+/**
+ * {@link DocumentDbConfigurationSupport} is deprecated.
+ * Instead use CosmosConfigurationSupport, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public abstract class DocumentDbConfigurationSupport {
 
     @Bean

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbOperations.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbOperations.java
@@ -17,6 +17,11 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
+/**
+ * {@link DocumentDbOperations} is deprecated.
+ * Instead use CosmosOperations, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public interface DocumentDbOperations {
 
     String getCollectionName(Class<?> entityClass);

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbTemplate.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbTemplate.java
@@ -51,10 +51,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * 
- * @author Domenico Sibilio
- *
+ * {@link DocumentDbTemplate} is deprecated.
+ * Instead use CosmosTemplate, which is introduced in 2.2.0 version.
  */
+@Deprecated
 @Slf4j
 public class DocumentDbTemplate implements DocumentDbOperations, ApplicationContextAware {
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbTemplate.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbTemplate.java
@@ -258,14 +258,13 @@ public class DocumentDbTemplate implements DocumentDbOperations, ApplicationCont
     @Override
     public DocumentCollection createCollectionIfNotExists(@NonNull DocumentDbEntityInformation<?, ?> information) {
         final CosmosContainerResponse response = cosmosClient
-                .createDatabaseIfNotExists(this.databaseName)
-                .flatMap(cosmosDatabaseResponse -> cosmosDatabaseResponse
-                        .database()
-                        .createContainerIfNotExists(information.getCollectionName(),
-                                "/" + information.getPartitionKeyFieldName(),
-                            information.getRequestUnit())
-                        .map(cosmosContainerResponse -> cosmosContainerResponse))
-                .block();
+            .createDatabaseIfNotExists(this.databaseName)
+            .flatMap(cosmosDatabaseResponse -> cosmosDatabaseResponse
+                .database()
+                .createContainerIfNotExists(information.getCollectionName(),
+                    "/" + information.getPartitionKeyFieldName(),
+                    information.getRequestUnit()))
+            .block();
         if (response == null) {
             throw new DocumentDBAccessException("Failed to create collection");
         }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/convert/MappingDocumentDbConverter.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/convert/MappingDocumentDbConverter.java
@@ -35,6 +35,11 @@ import java.util.Date;
 
 import static com.microsoft.azure.spring.data.cosmosdb.Constants.ISO_8601_COMPATIBLE_DATE_PATTERN;
 
+/**
+ * {@link MappingDocumentDbConverter} is deprecated.
+ * Instead use MappingCosmosConverter, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class MappingDocumentDbConverter
     implements EntityConverter<DocumentDbPersistentEntity<?>, DocumentDbPersistentProperty,
     Object, CosmosItemProperties>,

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/convert/MappingDocumentDbConverter.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/convert/MappingDocumentDbConverter.java
@@ -7,9 +7,7 @@ package com.microsoft.azure.spring.data.cosmosdb.core.convert;
 
 import com.azure.data.cosmos.CosmosItemProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.microsoft.azure.documentdb.Document;
 import com.microsoft.azure.spring.data.cosmosdb.Constants;
 import com.microsoft.azure.spring.data.cosmosdb.core.mapping.DocumentDbPersistentEntity;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/BasicDocumentDbPersistentEntity.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/BasicDocumentDbPersistentEntity.java
@@ -15,7 +15,11 @@ import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
-
+/**
+ * {@link BasicDocumentDbPersistentEntity} is deprecated.
+ * Instead use BasicCosmosPersistentEntity, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class BasicDocumentDbPersistentEntity<T> extends BasicPersistentEntity<T, DocumentDbPersistentProperty>
         implements DocumentDbPersistentEntity<T>, ApplicationContextAware {
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/BasicDocumentDbPersistentProperty.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/BasicDocumentDbPersistentProperty.java
@@ -12,7 +12,11 @@ import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 
-
+/**
+ * {@link BasicDocumentDbPersistentProperty} is deprecated.
+ * Instead use BasicCosmosPersistentProperty, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class BasicDocumentDbPersistentProperty extends AnnotationBasedPersistentProperty<DocumentDbPersistentProperty>
         implements DocumentDbPersistentProperty {
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/DocumentDbMappingContext.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/DocumentDbMappingContext.java
@@ -12,7 +12,11 @@ import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.TypeInformation;
 
-
+/**
+ * {@link DocumentDbMappingContext} is deprecated.
+ * Instead use CosmosMappingContext, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbMappingContext
         extends AbstractMappingContext<BasicDocumentDbPersistentEntity<?>, DocumentDbPersistentProperty> {
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/DocumentDbPersistentEntity.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/DocumentDbPersistentEntity.java
@@ -8,7 +8,11 @@ package com.microsoft.azure.spring.data.cosmosdb.core.mapping;
 
 import org.springframework.data.mapping.PersistentEntity;
 
-
+/**
+ * {@link DocumentDbPersistentEntity} is deprecated.
+ * Instead use CosmosPersistentEntity, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public interface DocumentDbPersistentEntity<T> extends PersistentEntity<T, DocumentDbPersistentProperty> {
 
     String getCollection();

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/DocumentDbPersistentProperty.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/mapping/DocumentDbPersistentProperty.java
@@ -8,6 +8,10 @@ package com.microsoft.azure.spring.data.cosmosdb.core.mapping;
 
 import org.springframework.data.mapping.PersistentProperty;
 
-
+/**
+ * {@link DocumentDbPersistentProperty} is deprecated.
+ * Instead use CosmosPersistentProperty, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public interface DocumentDbPersistentProperty extends PersistentProperty<DocumentDbPersistentProperty> {
 }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/query/DocumentDbPageRequest.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/query/DocumentDbPageRequest.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Sort;
  * to help query next page.
  * <p>
  * The requestContinuation token should be saved after each request and reused in later queries.
+ *
+ * @Deprecated since 2.1.8, Instead use CosmosPageRequest which is introduced in 2.2.0 version.
  */
+@Deprecated
 public class DocumentDbPageRequest extends PageRequest {
     private static final long serialVersionUID = 6093304300037688375L;
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/exception/DocumentDBAccessException.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/exception/DocumentDBAccessException.java
@@ -8,6 +8,11 @@ package com.microsoft.azure.spring.data.cosmosdb.exception;
 import org.springframework.dao.DataAccessException;
 import org.springframework.lang.Nullable;
 
+/**
+ * {@link DocumentDBAccessException} is deprecated.
+ * Instead use CosmosDBAccessException, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDBAccessException extends DataAccessException {
     public DocumentDBAccessException(String msg) {
         super(msg);

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/DocumentDbRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/DocumentDbRepository.java
@@ -25,11 +25,19 @@ public interface DocumentDbRepository<T, ID extends Serializable> extends Paging
      * Retrieves an entity by its id.
      *
      * @param id must not be {@literal null}.
-     * @param partitionKey partition key value of entity
+     * @param partitionKey partition key value of entity, must not be null.
      * @return the entity with the given id or {@literal Optional#empty()} if none found
      * @throws IllegalArgumentException if {@code id} is {@literal null}.
      */
     Optional<T> findById(ID id, PartitionKey partitionKey);
+
+    /**
+     * Deletes an entity by its id and partition key.
+     * @param id must not be {@literal null}.
+     * @param partitionKey partition key value of the entity, must not be null.
+     * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
+     */
+    void deleteById(ID id, PartitionKey partitionKey);
 
 }
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/DocumentDbRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/DocumentDbRepository.java
@@ -13,6 +13,11 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import java.io.Serializable;
 import java.util.Optional;
 
+/**
+ * {@link DocumentDbRepository} is deprecated.
+ * Instead use CosmosRepository, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 @NoRepositoryBean
 public interface DocumentDbRepository<T, ID extends Serializable> extends PagingAndSortingRepository<T, ID> {
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/ReactiveCosmosRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/ReactiveCosmosRepository.java
@@ -16,9 +16,18 @@ public interface ReactiveCosmosRepository<T, K> extends ReactiveSortingRepositor
     /**
      * Retrieves an entity by its id and partition key.
      * @param id must not be {@literal null}.
-     * @param partitionKey partition key value of the entity.
+     * @param partitionKey partition key value of the entity, must not be null.
      * @return {@link Mono} emitting the entity with the given id or {@link Mono#empty()} if none found.
      * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
      */
     Mono<T> findById(K id, PartitionKey partitionKey);
+
+    /**
+     * Deletes an entity by its id and partition key.
+     * @param id must not be {@literal null}.
+     * @param partitionKey partition key value of the entity, must not be null.
+     * @return {@link Mono} emitting the void Mono.
+     * @throws IllegalArgumentException in case the given {@code id} is {@literal null}.
+     */
+    Mono<Void> deleteById(K id, PartitionKey partitionKey);
 }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/config/DocumentDbRepositoriesRegistrar.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/config/DocumentDbRepositoriesRegistrar.java
@@ -11,7 +11,11 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
 
 import java.lang.annotation.Annotation;
 
-
+/**
+ * {@link DocumentDbRepositoriesRegistrar} is deprecated.
+ * Instead use CosmosRepositoriesRegistrar, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbRepositoriesRegistrar extends RepositoryBeanDefinitionRegistrarSupport {
 
     @Override

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/config/DocumentDbRepositoryConfigurationExtension.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/config/DocumentDbRepositoryConfigurationExtension.java
@@ -21,7 +21,11 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 
-
+/**
+ * {@link DocumentDbRepositoryConfigurationExtension} is deprecated.
+ * Instead use CosmosRepositoryConfigurationExtension, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbRepositoryConfigurationExtension extends RepositoryConfigurationExtensionSupport {
 
     @Override

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/config/EnableDocumentDbRepositories.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/config/EnableDocumentDbRepositories.java
@@ -15,7 +15,11 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
 
 import java.lang.annotation.*;
 
-
+/**
+ * {@link EnableDocumentDbRepositories} is deprecated.
+ * Instead use EnableCosmosRepositories, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/AbstractDocumentDbQuery.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/AbstractDocumentDbQuery.java
@@ -10,6 +10,11 @@ import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 
+/**
+ * {@link AbstractDocumentDbQuery} is deprecated.
+ * Instead use AbstractCosmosQuery, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public abstract class AbstractDocumentDbQuery implements RepositoryQuery {
 
     private final DocumentDbQueryMethod method;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbEntityMetadata.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbEntityMetadata.java
@@ -7,6 +7,11 @@ package com.microsoft.azure.spring.data.cosmosdb.repository.query;
 
 import org.springframework.data.repository.core.EntityMetadata;
 
+/**
+ * {@link SimpleDocumentDbEntityMetadata} is deprecated.
+ * Instead use CosmosEntityMetadata, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public interface DocumentDbEntityMetadata<T> extends EntityMetadata {
     String getCollectionName();
 }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameter.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameter.java
@@ -8,6 +8,11 @@ package com.microsoft.azure.spring.data.cosmosdb.repository.query;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.repository.query.Parameter;
 
+/**
+ * {@link DocumentDbParameter} is deprecated.
+ * Instead use CosmosParameter, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbParameter extends Parameter {
 
     public DocumentDbParameter(MethodParameter parameter) {

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameterAccessor.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameterAccessor.java
@@ -7,6 +7,11 @@ package com.microsoft.azure.spring.data.cosmosdb.repository.query;
 
 import org.springframework.data.repository.query.ParameterAccessor;
 
+/**
+ * {@link DocumentDbParameterAccessor} is deprecated.
+ * Instead use CosmosParameterAccessor, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public interface DocumentDbParameterAccessor extends ParameterAccessor {
     Object[] getValues();
 }

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameterParameterAccessor.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameterParameterAccessor.java
@@ -10,6 +10,11 @@ import org.springframework.data.repository.query.ParametersParameterAccessor;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * {@link DocumentDbParameterParameterAccessor} is deprecated.
+ * Instead use CosmosParameterParameterAccessor, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbParameterParameterAccessor extends ParametersParameterAccessor
         implements DocumentDbParameterAccessor {
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameters.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbParameters.java
@@ -11,6 +11,11 @@ import org.springframework.data.repository.query.Parameters;
 import java.lang.reflect.Method;
 import java.util.List;
 
+/**
+ * {@link DocumentDbParameters} is deprecated.
+ * Instead use CosmosParameters, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbParameters extends Parameters<DocumentDbParameters, DocumentDbParameter> {
 
     public DocumentDbParameters(Method method) {

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbQueryCreator.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbQueryCreator.java
@@ -23,6 +23,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * {@link DocumentDbQueryCreator} is deprecated.
+ * Instead use CosmosQueryCreator, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbQueryCreator extends AbstractQueryCreator<DocumentQuery, Criteria> {
 
     private final MappingContext<?, DocumentDbPersistentProperty> mappingContext;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbQueryExecution.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbQueryExecution.java
@@ -10,6 +10,11 @@ import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentDbPageRequest
 import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import org.springframework.data.domain.Pageable;
 
+/**
+ * {@link DocumentDbQueryExecution} is deprecated.
+ * Instead use CosmosQueryExecution, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public interface DocumentDbQueryExecution {
     Object execute(DocumentQuery query, Class<?> type, String collection);
 

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbQueryMethod.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/DocumentDbQueryMethod.java
@@ -13,6 +13,11 @@ import org.springframework.data.repository.query.QueryMethod;
 
 import java.lang.reflect.Method;
 
+/**
+ * {@link DocumentDbQueryMethod} is deprecated.
+ * Instead use CosmosQueryMethod, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbQueryMethod extends QueryMethod {
 
     private DocumentDbEntityMetadata<?> metadata;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/PartTreeDocumentDbQuery.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/PartTreeDocumentDbQuery.java
@@ -13,6 +13,11 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.parser.PartTree;
 
+/**
+ * {@link PartTreeDocumentDbQuery} is deprecated.
+ * Instead use PartTreeCosmosQuery, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class PartTreeDocumentDbQuery extends AbstractDocumentDbQuery {
 
     private final PartTree tree;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/SimpleDocumentDbEntityMetadata.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/query/SimpleDocumentDbEntityMetadata.java
@@ -8,6 +8,11 @@ package com.microsoft.azure.spring.data.cosmosdb.repository.query;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.DocumentDbEntityInformation;
 import org.springframework.util.Assert;
 
+/**
+ * {@link SimpleDocumentDbEntityMetadata} is deprecated.
+ * Instead use SimpleCosmosEntityMetadata, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class SimpleDocumentDbEntityMetadata<T> implements DocumentDbEntityMetadata<T> {
 
     private final Class<T> type;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformation.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbEntityInformation.java
@@ -29,7 +29,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-
+/**
+ * {@link DocumentDbEntityInformation} is deprecated.
+ * Instead use CosmosEntityInformation, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbEntityInformation<T, ID> extends AbstractEntityInformation<T, ID> {
 
     private static final String ETAG = "_etag";

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbRepositoryFactory.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbRepositoryFactory.java
@@ -25,7 +25,11 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
-
+/**
+ * {@link DocumentDbRepositoryFactory} is deprecated.
+ * Instead use CosmosRepositoryFactory, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbRepositoryFactory extends RepositoryFactorySupport {
 
     private final ApplicationContext applicationContext;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbRepositoryFactoryBean.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/DocumentDbRepositoryFactoryBean.java
@@ -19,7 +19,11 @@ import org.springframework.data.repository.core.support.RepositoryFactorySupport
 
 import java.io.Serializable;
 
-
+/**
+ * {@link DocumentDbRepositoryFactoryBean} is deprecated.
+ * Instead use CosmosRepositoryFactoryBean, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class DocumentDbRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
         extends RepositoryFactoryBeanSupport<T, S, ID>
         implements ApplicationContextAware {

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleDocumentDbRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleDocumentDbRepository.java
@@ -186,6 +186,14 @@ public class SimpleDocumentDbRepository<T, ID extends Serializable> implements D
         operation.deleteById(information.getCollectionName(), id, null);
     }
 
+    @Override
+    public void deleteById(ID id, PartitionKey partitionKey) {
+        Assert.notNull(id, "id to be deleted should not be null");
+        Assert.notNull(partitionKey, "partitionKey to be deleted should not be null");
+
+        operation.deleteById(information.getCollectionName(), id, partitionKey);
+    }
+
     /**
      * delete one document per entity
      *

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleDocumentDbRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleDocumentDbRepository.java
@@ -27,6 +27,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
+/**
+ * {@link SimpleDocumentDbRepository} is deprecated.
+ * Instead use SimpleCosmosRepository, which is introduced in 2.2.0 version.
+ */
+@Deprecated
 public class SimpleDocumentDbRepository<T, ID extends Serializable> implements DocumentDbRepository<T, ID> {
 
     private final DocumentDbOperations operation;

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleReactiveCosmosRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleReactiveCosmosRepository.java
@@ -136,6 +136,15 @@ public class SimpleReactiveCosmosRepository<T, K extends Serializable> implement
     }
 
     @Override
+    public Mono<Void> deleteById(K id, PartitionKey partitionKey) {
+        Assert.notNull(id, "Id must not be null!");
+        Assert.notNull(partitionKey, "PartitionKey must not be null!");
+
+        return cosmosOperations.deleteById(entityInformation.getCollectionName(), id, partitionKey);
+
+    }
+
+    @Override
     public Mono<Void> deleteById(Publisher<K> publisher) {
         Assert.notNull(publisher, "Id must not be null!");
 

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/common/PageTestUtils.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/common/PageTestUtils.java
@@ -39,6 +39,6 @@ public class PageTestUtils {
 
         final JSONObject jsonObject = new JSONObject(tokenJson);
 
-        return jsonObject.isNull("token");
+        return jsonObject.isNull("compositeToken");
     }
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbTemplateIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/DocumentDbTemplateIT.java
@@ -295,7 +295,7 @@ public class DocumentDbTemplateIT {
         dbTemplate.insert(TEST_PERSON_3,
                 new PartitionKey(personInfo.getPartitionKeyFieldValue(TEST_PERSON_3)));
 
-        final Sort sort = new Sort(Sort.Direction.DESC, "firstName");
+        final Sort sort = Sort.by(Sort.Direction.DESC, "firstName");
         final PageRequest pageRequest = DocumentDbPageRequest.of(0, PAGE_SIZE_3, null, sort);
 
         final Page<Person> page = dbTemplate.findAll(pageRequest, Person.class, collectionName);
@@ -323,7 +323,7 @@ public class DocumentDbTemplateIT {
         dbTemplate.insert(testPerson5,
                 new PartitionKey(personInfo.getPartitionKeyFieldValue(testPerson5)));
 
-        final Sort sort = new Sort(Sort.Direction.ASC, "firstName");
+        final Sort sort = Sort.by(Sort.Direction.ASC, "firstName");
         final PageRequest pageRequest = DocumentDbPageRequest.of(0, PAGE_SIZE_3, null, sort);
 
         final Page<Person> firstPage = dbTemplate.findAll(pageRequest, Person.class,

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplateIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplateIT.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.spring.data.cosmosdb.core.query.Criteria;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.CriteriaType;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Person;
+import com.microsoft.azure.spring.data.cosmosdb.exception.DocumentDBAccessException;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.DocumentDbEntityInformation;
 import io.reactivex.subscribers.TestSubscriber;
 import org.junit.After;
@@ -122,7 +123,7 @@ public class ReactiveCosmosTemplateIT {
         testSubscriber.assertNotComplete();
         testSubscriber.assertTerminated();
         assertThat(testSubscriber.errors()).hasSize(1);
-        assertThat(((List) testSubscriber.getEvents().get(1)).get(0)).isInstanceOf(CosmosClientException.class);
+        assertThat(((List) testSubscriber.getEvents().get(1)).get(0)).isInstanceOf(DocumentDBAccessException.class);
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplateIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplateIT.java
@@ -5,7 +5,6 @@
  */
 package com.microsoft.azure.spring.data.cosmosdb.core;
 
-import com.azure.data.cosmos.CosmosClientException;
 import com.azure.data.cosmos.CosmosKeyCredential;
 import com.azure.data.cosmos.PartitionKey;
 import com.microsoft.azure.spring.data.cosmosdb.CosmosDbFactory;

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/AddressRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/AddressRepositoryIT.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.spring.data.cosmosdb.common.TestConstants;
 import com.microsoft.azure.spring.data.cosmosdb.common.TestUtils;
 import com.microsoft.azure.spring.data.cosmosdb.core.DocumentDbTemplate;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Address;
+import com.microsoft.azure.spring.data.cosmosdb.exception.DocumentDBAccessException;
 import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import com.microsoft.azure.spring.data.cosmosdb.repository.repository.AddressRepository;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.DocumentDbEntityInformation;
@@ -163,6 +164,25 @@ public class AddressRepositoryIT {
 
         assertThat(result.size()).isEqualTo(2);
         assertThat(result.get(0).getCity()).isNotEqualTo(TEST_ADDRESS1_PARTITION1.getCity());
+    }
+
+    @Test(expected = DocumentDBAccessException.class)
+    public void testDeleteByIdAndPartitionKey() {
+        final long count = repository.count();
+        assertThat(count).isEqualTo(4);
+
+        final Optional<Address> addressById = repository.findById(TEST_ADDRESS1_PARTITION1.getPostalCode(),
+            new PartitionKey(TEST_ADDRESS1_PARTITION1.getCity()));
+        assertThat(addressById.isPresent()).isTrue();
+
+        repository.deleteById(TEST_ADDRESS1_PARTITION1.getPostalCode(),
+            new PartitionKey(TEST_ADDRESS1_PARTITION1.getCity()));
+
+        final List<Address> result = TestUtils.toList(repository.findAll());
+        assertThat(result.size()).isEqualTo(3);
+
+        repository.findById(TEST_ADDRESS1_PARTITION1.getPostalCode(),
+            new PartitionKey(TEST_ADDRESS1_PARTITION1.getCity()));
     }
 
     @Test


### PR DESCRIPTION
* DocumentDb APIs have been deprecated in this PR. 
* Updated azure-documentdb and azure-cosmos to latest versions. 
* Updated CosmosClient to connect on Direct Mode Https Protocol. 
* Fixed ISO date pattern: https://github.com/microsoft/spring-data-cosmosdb/issues/440