### PR TITLE
Single result queries

### DIFF
--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/SingleResponseRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/SingleResponseRepositoryIT.java
@@ -7,9 +7,11 @@
 package com.microsoft.azure.spring.data.cosmosdb.repository.integration;
 
 import com.microsoft.azure.spring.data.cosmosdb.domain.Contact;
+import com.microsoft.azure.spring.data.cosmosdb.domain.Course;
 import com.microsoft.azure.spring.data.cosmosdb.exception.CosmosDBAccessException;
 import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import com.microsoft.azure.spring.data.cosmosdb.repository.repository.ContactRepository;
+import com.microsoft.azure.spring.data.cosmosdb.repository.repository.ReactiveCourseRepository;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -18,6 +20,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.Iterator;
 import java.util.List;
@@ -28,9 +32,13 @@ import java.util.Optional;
 public class SingleResponseRepositoryIT {
 
     private static final Contact TEST_CONTACT = new Contact("testId", "faketitle");
+    private static final Course TEST_COURSE = new Course("1", "Course 1", "Department 1");
 
     @Autowired
     private ContactRepository repository;
+
+    @Autowired
+    private ReactiveCourseRepository reactiveRepository;
 
     @Before
     public void setUp() {
@@ -75,6 +83,15 @@ public class SingleResponseRepositoryIT {
         Assert.assertTrue(contactIterator.hasNext());
         Assert.assertEquals(TEST_CONTACT, contactIterator.next());
         Assert.assertFalse(contactIterator.hasNext());
+    }
+
+    @Test
+    public void testShouldFindSingleEntityReactive() {
+        final Mono<Course> save = reactiveRepository.save(TEST_COURSE);
+        StepVerifier.create(save).expectNext(TEST_COURSE).verifyComplete();
+
+        final Mono<Course> find = reactiveRepository.findByName(TEST_COURSE.getName());
+        StepVerifier.create(find).expectNext(TEST_COURSE).expectComplete().verify();
     }
 
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/SingleResponseRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/SingleResponseRepositoryIT.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.spring.data.cosmosdb.repository.integration;
+
+import com.microsoft.azure.spring.data.cosmosdb.domain.Contact;
+import com.microsoft.azure.spring.data.cosmosdb.exception.CosmosDBAccessException;
+import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
+import com.microsoft.azure.spring.data.cosmosdb.repository.repository.ContactRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestRepositoryConfig.class)
+public class SingleResponseRepositoryIT {
+
+    private static final Contact TEST_CONTACT = new Contact("testId", "faketitle");
+
+    @Autowired
+    private ContactRepository repository;
+
+    @Before
+    public void setUp() {
+        repository.save(TEST_CONTACT);
+    }
+
+    @After
+    public void cleanup() {
+        repository.deleteAll();
+    }
+
+    @Test
+    public void testShouldFindSingleEntity() {
+        final Contact contact = repository.findOneByTitle(TEST_CONTACT.getTitle());
+
+        Assert.assertEquals(TEST_CONTACT, contact);
+    }
+
+    @Test
+    public void testShouldFindSingleOptionalEntity() {
+        final Optional<Contact> contact = repository.findOptionallyByTitle(TEST_CONTACT.getTitle());
+        Assert.assertTrue(contact.isPresent());
+        Assert.assertEquals(TEST_CONTACT, contact.get());
+
+        Assert.assertFalse(repository.findOptionallyByTitle("not here").isPresent());
+    }
+
+    @Test(expected = CosmosDBAccessException.class)
+    public void testShouldFailIfMultipleResultsReturned() {
+        repository.save(new Contact("testId2", TEST_CONTACT.getTitle()));
+
+        repository.findOneByTitle(TEST_CONTACT.getTitle());
+    }
+
+    @Test
+    public void testShouldAllowListAndIterableResponses() {
+        final List<Contact> contactList = repository.findByTitle(TEST_CONTACT.getTitle());
+        Assert.assertEquals(TEST_CONTACT, contactList.get(0));
+        Assert.assertEquals(1, contactList.size());
+
+        final Iterator<Contact> contactIterator = repository.findByLogicId(TEST_CONTACT.getLogicId()).iterator();
+        Assert.assertTrue(contactIterator.hasNext());
+        Assert.assertEquals(TEST_CONTACT, contactIterator.next());
+        Assert.assertFalse(contactIterator.hasNext());
+    }
+
+}

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ContactRepository.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ContactRepository.java
@@ -10,8 +10,15 @@ import com.microsoft.azure.spring.data.cosmosdb.repository.CosmosRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ContactRepository extends CosmosRepository<Contact, String> {
     List<Contact> findByTitle(String title);
+    Iterable<Contact> findByLogicId(String title);
+
+    Contact findOneByTitle(String title);
+
+    Optional<Contact> findOptionallyByTitle(String title);
+
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ReactiveCourseRepository.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ReactiveCourseRepository.java
@@ -8,10 +8,13 @@ package com.microsoft.azure.spring.data.cosmosdb.repository.repository;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Course;
 import com.microsoft.azure.spring.data.cosmosdb.repository.ReactiveCosmosRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 
 public interface ReactiveCourseRepository extends ReactiveCosmosRepository<Course, String> {
 
     Flux<Course> findByDepartmentIn(Collection<String> departments);
+
+    Mono<Course> findByName(String name);
 }


### PR DESCRIPTION
This is a rebase of https://github.com/microsoft/spring-data-cosmosdb/pull/381, I don't have permissions to update the branch so opening this as a new PR.

@kushagraThapar would you mind taking a look?  Thanks!

This PR is a feature enhancement, adding the ability to have Repository methods that return a single object or Optional. Let's say I have the following...

class Repository extends CosmosRepository<Foo> {
    Foo findBySomething(String something); 
}
Calling this method will currently result in a ClassCastException since it assumes a return type of List.
In addition, the findById method on CosmosRepository declares the following method - Optional<T> findById(ID id, PartitionKey partitionKey); The contract says the Optional should contain the entity type but it does not - it contains a list of entity types. I would argue that the latter is a bug since the value returned in the Optional differs from what the method says should be returned.

The workaround would be to not use any methods that returned a single entity and to cast the returned value from the Optional to a List (since the actual value and the contract value are different) and deal with the single item list.

Does this help? Let me know if you'd like additional details.