### PR TITLE
cosmos will reject a document if it doesn't have an id so auto create one if needed

### DIFF
--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/annotation/GeneratedValue.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/annotation/GeneratedValue.java
@@ -1,0 +1,12 @@
+package com.microsoft.azure.spring.data.cosmosdb.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface GeneratedValue {
+}

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/CosmosTemplateIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/CosmosTemplateIT.java
@@ -18,6 +18,7 @@ import com.microsoft.azure.spring.data.cosmosdb.core.query.Criteria;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.CriteriaType;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Person;
+import com.microsoft.azure.spring.data.cosmosdb.domain.Project;
 import com.microsoft.azure.spring.data.cosmosdb.exception.CosmosDBAccessException;
 import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.CosmosEntityInformation;
@@ -116,6 +117,21 @@ public class CosmosTemplateIT {
     @After
     public void cleanup() {
         cosmosTemplate.deleteAll(Person.class.getSimpleName(), Person.class);
+    }
+
+    @Test(expected = CosmosDBAccessException.class)
+    public void testInsertShouldFailIfColumnNotAnnotatedWithAutoGenerate() {
+        final Person person = new Person(null, FIRST_NAME, LAST_NAME, HOBBIES, ADDRESSES);
+        cosmosTemplate.insert(Person.class.getSimpleName(), person, new PartitionKey(person.getLastName()));
+    }
+
+    @Test
+    public void testInsertShouldGenerateIdIfColumnAnnotatedWithAutoGenerate() {
+        final Project project = new Project(null, "project", "creator",
+                                            true, 0L, 0L);
+        final Project insertedProject = cosmosTemplate.insert(Project.class.getSimpleName(),
+                                                              project, new PartitionKey(project.getCreator()));
+        assertThat(insertedProject.getId()).isNotNull();
     }
 
     @Test(expected = CosmosDBAccessException.class)

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/domain/Project.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/domain/Project.java
@@ -5,6 +5,7 @@
  */
 package com.microsoft.azure.spring.data.cosmosdb.domain;
 
+import com.microsoft.azure.spring.data.cosmosdb.annotation.GeneratedValue;
 import com.microsoft.azure.spring.data.cosmosdb.common.TestConstants;
 import com.microsoft.azure.spring.data.cosmosdb.core.mapping.DocumentIndexingPolicy;
 import com.microsoft.azure.spring.data.cosmosdb.core.mapping.PartitionKey;
@@ -18,6 +19,7 @@ import org.springframework.data.annotation.Id;
 public class Project {
 
     @Id
+    @GeneratedValue
     private String id;
 
     private String name;


### PR DESCRIPTION
If save is invoked and the id of the object is null, cosmos will reject the call. 
 `SimpleCosmosRepository#save` specifically checks for this case and calls either `CosmosOperations#insert` or `CosmosOperations#upsert`.  Since there is a separate branching path for inserts in the case where id is null, I assume this is supposed to work (I'm guessing Cosmos supported this at some point but apparently no longer).  This PR replaces a null id with a random UUID.  