### PR TITLE
Int test updates

### DIFF
--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactoryTestIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/CosmosDbFactoryTestIT.java
@@ -7,10 +7,12 @@ package com.microsoft.azure.spring.data.cosmosdb;
 
 import com.microsoft.azure.spring.data.cosmosdb.config.CosmosDBConfig;
 import com.microsoft.azure.spring.data.cosmosdb.exception.CosmosDBAccessException;
+import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.COSMOSDB_FAKE_CONNECTION_STRING;
@@ -20,8 +22,8 @@ import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.COSM
 import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.DB_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@PropertySource(value = {"classpath:application.properties"})
 @RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestRepositoryConfig.class)
 public class CosmosDbFactoryTestIT {
 
     @Value("${cosmosdb.uri:}")

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/config/AbstractCosmosConfigurationIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/config/AbstractCosmosConfigurationIT.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.util.StringUtils;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -94,12 +95,16 @@ public class AbstractCosmosConfigurationIT {
         @Value("${cosmosdb.key:}")
         private String cosmosDbKey;
 
+        @Value("${cosmosdb.database:}")
+        private String database;
+
         @Mock
         private CosmosClient mockClient;
 
         @Bean
         public CosmosDBConfig getConfig() {
-            return CosmosDBConfig.builder(cosmosDbUri, cosmosDbKey, TestConstants.DB_NAME).build();
+            final String dbName = StringUtils.hasText(this.database) ? this.database : TestConstants.DB_NAME;
+            return CosmosDBConfig.builder(cosmosDbUri, cosmosDbKey, dbName).build();
         }
 
         @Override
@@ -126,6 +131,9 @@ public class AbstractCosmosConfigurationIT {
         @Value("${cosmosdb.key:}")
         private String cosmosDbKey;
 
+        @Value("${cosmosdb.database:}")
+        private String database;
+
         private RequestOptions getRequestOptions() {
             final RequestOptions options = new RequestOptions();
 
@@ -137,8 +145,9 @@ public class AbstractCosmosConfigurationIT {
 
         @Bean
         public CosmosDBConfig getConfig() {
+            final String dbName = StringUtils.hasText(this.database) ? this.database : TestConstants.DB_NAME;
             final RequestOptions options = getRequestOptions();
-            return CosmosDBConfig.builder(cosmosDbUri, cosmosDbKey, TestConstants.DB_NAME)
+            return CosmosDBConfig.builder(cosmosDbUri, cosmosDbKey, dbName)
                     .requestOptions(options)
                     .build();
         }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplatePartitionIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/core/ReactiveCosmosTemplatePartitionIT.java
@@ -13,6 +13,7 @@ import com.microsoft.azure.spring.data.cosmosdb.core.mapping.CosmosMappingContex
 import com.microsoft.azure.spring.data.cosmosdb.core.query.Criteria;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.DocumentQuery;
 import com.microsoft.azure.spring.data.cosmosdb.domain.PartitionPerson;
+import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.CosmosEntityInformation;
 import org.junit.After;
 import org.junit.Assert;
@@ -25,6 +26,7 @@ import org.springframework.boot.autoconfigure.domain.EntityScanner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.annotation.Persistent;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -50,18 +52,13 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@PropertySource(value = {"classpath:application.properties"})
+@ContextConfiguration(classes = TestRepositoryConfig.class)
 public class ReactiveCosmosTemplatePartitionIT {
     private static final PartitionPerson TEST_PERSON = new PartitionPerson(ID_1, FIRST_NAME, LAST_NAME,
             HOBBIES, ADDRESSES);
 
     private static final PartitionPerson TEST_PERSON_2 = new PartitionPerson(ID_2, NEW_FIRST_NAME,
             TEST_PERSON.getLastName(), HOBBIES, ADDRESSES);
-
-    @Value("${cosmosdb.uri}")
-    private String cosmosDbUri;
-    @Value("${cosmosdb.key}")
-    private String cosmosDbKey;
 
     private static ReactiveCosmosTemplate cosmosTemplate;
     private static String containerName;
@@ -71,12 +68,12 @@ public class ReactiveCosmosTemplatePartitionIT {
 
     @Autowired
     private ApplicationContext applicationContext;
+    @Autowired
+    private CosmosDBConfig dbConfig;
 
     @Before
     public void setUp() throws ClassNotFoundException {
         if (!initialized) {
-            final CosmosDBConfig dbConfig = CosmosDBConfig.builder(cosmosDbUri, cosmosDbKey,
-                DB_NAME).build();
             final CosmosDbFactory dbFactory = new CosmosDbFactory(dbConfig);
 
             final CosmosMappingContext mappingContext = new CosmosMappingContext();
@@ -88,7 +85,7 @@ public class ReactiveCosmosTemplatePartitionIT {
 
             final MappingCosmosConverter dbConverter = new MappingCosmosConverter(mappingContext,
                 null);
-            cosmosTemplate = new ReactiveCosmosTemplate(dbFactory, dbConverter, DB_NAME);
+            cosmosTemplate = new ReactiveCosmosTemplate(dbFactory, dbConverter, dbConfig.getDatabase());
             cosmosTemplate.createCollectionIfNotExists(personInfo).block();
 
             initialized = true;

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/CosmosAnnotationIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/CosmosAnnotationIT.java
@@ -16,6 +16,7 @@ import com.microsoft.azure.spring.data.cosmosdb.core.convert.MappingCosmosConver
 import com.microsoft.azure.spring.data.cosmosdb.core.mapping.CosmosMappingContext;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Role;
 import com.microsoft.azure.spring.data.cosmosdb.domain.TimeToLiveSample;
+import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.CosmosEntityInformation;
 import org.junit.After;
 import org.junit.Before;
@@ -28,23 +29,20 @@ import org.springframework.boot.autoconfigure.domain.EntityScanner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.annotation.Persistent;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.Assert;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@PropertySource(value = {"classpath:application.properties"})
+@ContextConfiguration(classes = TestRepositoryConfig.class)
 public class CosmosAnnotationIT {
     private static final Role TEST_ROLE = new Role(TestConstants.ID_1, TestConstants.LEVEL,
             TestConstants.ROLE_NAME);
 
-    @Value("${cosmosdb.uri}")
-    private String dbUri;
-
-    @Value("${cosmosdb.key}")
-    private String dbKey;
-
     @Autowired
     private ApplicationContext applicationContext;
+    @Autowired
+    private CosmosDBConfig dbConfig;
 
     private static CosmosTemplate cosmosTemplate;
     private static CosmosContainerProperties collectionRole;
@@ -56,7 +54,6 @@ public class CosmosAnnotationIT {
     @Before
     public void setUp() throws ClassNotFoundException {
         if (!initialized) {
-            final CosmosDBConfig dbConfig = CosmosDBConfig.builder(dbUri, dbKey, TestConstants.DB_NAME).build();
             final CosmosDbFactory cosmosDbFactory = new CosmosDbFactory(dbConfig);
 
             roleInfo = new CosmosEntityInformation<>(Role.class);
@@ -67,7 +64,7 @@ public class CosmosAnnotationIT {
 
             final MappingCosmosConverter mappingConverter = new MappingCosmosConverter(dbContext, null);
 
-            cosmosTemplate = new CosmosTemplate(cosmosDbFactory, mappingConverter, TestConstants.DB_NAME);
+            cosmosTemplate = new CosmosTemplate(cosmosDbFactory, mappingConverter, dbConfig.getDatabase());
             initialized = true;
         }
         collectionRole = cosmosTemplate.createCollectionIfNotExists(roleInfo);

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/MemoRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/MemoRepositoryIT.java
@@ -241,4 +241,12 @@ public class MemoRepositoryIT {
     public void testFindByStartsWithWithException() {
         repository.findByMessageStartsWith(testMemo1.getMessage());
     }
+
+    @Test
+    public void testFindByStartsWith() {
+        final List<Memo> result = repository.findByMessageStartsWith(testMemo1.getMessage().substring(0, 10));
+        Assert.assertEquals(testMemo1, result.get(0));
+        Assert.assertEquals(1, result.size());
+    }
+
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/PageableAddressRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/PageableAddressRepositoryIT.java
@@ -11,6 +11,7 @@ import com.azure.data.cosmos.FeedOptions;
 import com.azure.data.cosmos.FeedResponse;
 import com.microsoft.azure.spring.data.cosmosdb.common.TestConstants;
 import com.microsoft.azure.spring.data.cosmosdb.common.TestUtils;
+import com.microsoft.azure.spring.data.cosmosdb.config.CosmosDBConfig;
 import com.microsoft.azure.spring.data.cosmosdb.core.CosmosTemplate;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.CosmosPageRequest;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Address;
@@ -35,7 +36,6 @@ import java.util.List;
 
 import static com.microsoft.azure.spring.data.cosmosdb.common.PageTestUtils.validateLastPage;
 import static com.microsoft.azure.spring.data.cosmosdb.common.PageTestUtils.validateNonLastPage;
-import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.DB_NAME;
 import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.PAGE_SIZE_1;
 import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.PAGE_SIZE_3;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,6 +63,9 @@ public class PageableAddressRepositoryIT {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Autowired
+    private CosmosDBConfig dbConfig;
 
     @Before
     public void setup() {
@@ -167,7 +170,7 @@ public class PageableAddressRepositoryIT {
 
         final CosmosClient cosmosClient = applicationContext.getBean(CosmosClient.class);
         final Flux<FeedResponse<CosmosItemProperties>> feedResponseFlux =
-            cosmosClient.getDatabase(DB_NAME)
+            cosmosClient.getDatabase(dbConfig.getDatabase())
                         .getContainer(entityInformation.getCollectionName())
                         .queryItems(query, options);
 

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/PageableMemoRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/PageableMemoRepositoryIT.java
@@ -9,6 +9,7 @@ import com.azure.data.cosmos.CosmosClient;
 import com.azure.data.cosmos.CosmosItemProperties;
 import com.azure.data.cosmos.FeedOptions;
 import com.azure.data.cosmos.FeedResponse;
+import com.microsoft.azure.spring.data.cosmosdb.config.CosmosDBConfig;
 import com.microsoft.azure.spring.data.cosmosdb.core.CosmosTemplate;
 import com.microsoft.azure.spring.data.cosmosdb.core.query.CosmosPageRequest;
 import com.microsoft.azure.spring.data.cosmosdb.domain.Importance;
@@ -38,7 +39,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.DB_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -59,6 +59,9 @@ public class PageableMemoRepositoryIT {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Autowired
+    private CosmosDBConfig dbConfig;
 
     private static Set<Memo> memoSet;
 
@@ -138,7 +141,7 @@ public class PageableMemoRepositoryIT {
         final String query = "SELECT * from c OFFSET " + skipCount + " LIMIT " + takeCount;
 
         final CosmosClient cosmosClient = applicationContext.getBean(CosmosClient.class);
-        return cosmosClient.getDatabase(DB_NAME)
+        return cosmosClient.getDatabase(dbConfig.getDatabase())
                     .getContainer(entityInformation.getCollectionName())
                     .queryItems(query, options);
     }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositorySortIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositorySortIT.java
@@ -26,6 +26,8 @@ import javax.annotation.PreDestroy;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static com.microsoft.azure.spring.data.cosmosdb.common.PageTestUtils.validateLastPage;
 
@@ -151,12 +153,15 @@ public class ProjectRepositorySortIT {
         this.repository.findAll(sort);
     }
 
-    @Test(expected = CosmosDBAccessException.class)
-    @Ignore // TODO(pan): Ignore this test case for now, will update this from service update.
     public void testFindAllSortWithIdName() {
-        final Sort sort = Sort.by(Sort.Direction.ASC, "id");
+        final List<Project> projectListSortedById = Lists.newArrayList(PROJECTS);
+        projectListSortedById.sort(Comparator.comparing(Project::getId));
 
-        this.repository.findAll(sort);
+        final Sort sort = Sort.by(Sort.Direction.ASC, "id");
+        final List<Project> results = StreamSupport.stream(this.repository.findAll(sort).spliterator(), false)
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(projectListSortedById, results);
     }
 
     @Test

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/RoleRepositoryCollectionIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/RoleRepositoryCollectionIT.java
@@ -143,7 +143,7 @@ public class RoleRepositoryCollectionIT {
                 .stream(this.repository.findAll(ascSort).spliterator(), false)
                 .collect(Collectors.toList());
         Assert.assertEquals(2, ascending.size());
-        Assert.assertEquals(0, DOMAIN.equals(ascending.get(0)));
+        Assert.assertEquals(DOMAIN, ascending.get(0));
         Assert.assertEquals(other, ascending.get(1));
 
         final Sort descSort = Sort.by(Sort.Direction.DESC, "number");

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/RoleRepositoryCollectionIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/RoleRepositoryCollectionIT.java
@@ -12,15 +12,24 @@ import com.microsoft.azure.spring.data.cosmosdb.exception.CosmosDBAccessExceptio
 import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
 import com.microsoft.azure.spring.data.cosmosdb.repository.repository.IntegerIdDomainRepository;
 import com.microsoft.azure.spring.data.cosmosdb.repository.support.CosmosEntityInformation;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.annotation.PreDestroy;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestRepositoryConfig.class)
@@ -37,6 +46,11 @@ public class RoleRepositoryCollectionIT {
     @Autowired
     private CosmosTemplate template;
 
+    @Before
+    public void setUp() {
+        repository.deleteAll();
+    }
+
     @PreDestroy
     public void cleanUpCollection() {
         template.deleteCollection(entityInformation.getCollectionName());
@@ -48,13 +62,25 @@ public class RoleRepositoryCollectionIT {
     }
 
     @Test
-    public void testSaveAll() {
-        this.repository.saveAll(Collections.singleton(DOMAIN));
+    public void testSaveAndFindById() {
+        Assert.assertNotNull(this.repository.save(DOMAIN));
+
+        final Optional<IntegerIdDomain> savedEntity = this.repository.findById(DOMAIN.getNumber());
+        Assert.assertTrue(savedEntity.isPresent());
+        Assert.assertEquals(DOMAIN, savedEntity.get());
     }
 
     @Test
-    public void testFindAll() {
-        this.repository.findAll();
+    public void testSaveAllAndFindAll() {
+        Assert.assertFalse(this.repository.findAll().iterator().hasNext());
+
+        final Set<IntegerIdDomain> entitiesToSave = Collections.singleton(DOMAIN);
+        this.repository.saveAll(entitiesToSave);
+
+        final Set<IntegerIdDomain> savedEntities = StreamSupport.stream(this.repository.findAll().spliterator(), false)
+                .collect(Collectors.toSet());
+
+        Assert.assertTrue(entitiesToSave.containsAll(savedEntities));
     }
 
     @Test
@@ -63,43 +89,87 @@ public class RoleRepositoryCollectionIT {
     }
 
     @Test
-    public void testFindById() {
-        this.repository.findById(DOMAIN.getNumber());
+    public void testCount() {
+        Assert.assertEquals(0, repository.count());
+        this.repository.save(DOMAIN);
+        Assert.assertEquals(1, repository.count());
     }
 
     @Test
-    public void testCount() {
-        this.repository.count();
+    public void testDeleteById() {
+        this.repository.save(DOMAIN);
+        this.repository.deleteById(DOMAIN.getNumber());
+        Assert.assertEquals(0, this.repository.count());
     }
 
     @Test(expected = CosmosDBAccessException.class)
-    public void testDeleteById() {
+    public void testDeleteByIdShouldFailIfNothingToDelete() {
         this.repository.deleteById(DOMAIN.getNumber());
     }
 
-    @Test(expected = CosmosDBAccessException.class)
+    @Test
     public void testDelete() {
+        this.repository.save(DOMAIN);
+        this.repository.delete(DOMAIN);
+        Assert.assertEquals(0, this.repository.count());
+    }
+
+    @Test(expected = CosmosDBAccessException.class)
+    public void testDeleteShouldFailIfNothingToDelete() {
         this.repository.delete(DOMAIN);
     }
 
     @Test
     public void testDeleteAll() {
+        this.repository.save(DOMAIN);
         this.repository.deleteAll(Collections.singleton(DOMAIN));
+        Assert.assertEquals(0, this.repository.count());
     }
 
     @Test
     public void testExistsById() {
-        this.repository.existsById(DOMAIN.getNumber());
+        this.repository.save(DOMAIN);
+        Assert.assertTrue(this.repository.existsById(DOMAIN.getNumber()));
     }
 
     @Test
     public void testFindAllSort() {
-        this.repository.findAll(Sort.unsorted());
+        final IntegerIdDomain other = new IntegerIdDomain(DOMAIN.getNumber() + 1, "other-name");
+        this.repository.save(other);
+        this.repository.save(DOMAIN);
+
+        final Sort ascSort = Sort.by(Sort.Direction.ASC, "number");
+        final List<IntegerIdDomain> ascending = StreamSupport
+                .stream(this.repository.findAll(ascSort).spliterator(), false)
+                .collect(Collectors.toList());
+        Assert.assertEquals(2, ascending.size());
+        Assert.assertEquals(0, DOMAIN.equals(ascending.get(0)));
+        Assert.assertEquals(other, ascending.get(1));
+
+        final Sort descSort = Sort.by(Sort.Direction.DESC, "number");
+        final List<IntegerIdDomain> descending = StreamSupport
+                .stream(this.repository.findAll(descSort).spliterator(), false)
+                .collect(Collectors.toList());
+        Assert.assertEquals(2, descending.size());
+        Assert.assertEquals(other, descending.get(0));
+        Assert.assertEquals(DOMAIN, descending.get(1));
+
     }
 
     @Test
     public void testFindAllPageable() {
-        final CosmosPageRequest pageRequest = new CosmosPageRequest(0, 3, null);
-        this.repository.findAll(pageRequest);
+        final IntegerIdDomain other = new IntegerIdDomain(DOMAIN.getNumber() + 1, "other-name");
+        this.repository.save(DOMAIN);
+        this.repository.save(other);
+
+        final Page<IntegerIdDomain> page1 = this.repository.findAll(new CosmosPageRequest(0, 1, null));
+        final Iterator<IntegerIdDomain> page1Iterator = page1.iterator();
+        Assert.assertTrue(page1Iterator.hasNext());
+        Assert.assertEquals(DOMAIN, page1Iterator.next());
+
+        final Page<IntegerIdDomain> page2 = this.repository.findAll(new CosmosPageRequest(1, 1, null));
+        final Iterator<IntegerIdDomain> page2Iterator = page2.iterator();
+        Assert.assertTrue(page2Iterator.hasNext());
+        Assert.assertEquals(DOMAIN, page2Iterator.next());
     }
 }


### PR DESCRIPTION
The TestRepositoryConfig configuration allows for specifying the cosmos database to use for integration tests via the `cosmosdb.database` property name.  This minimizes the number of collections created which is very useful if you don't have unlimited Azure credits.  Instead of injecting `cosmosdb.uri` and `cosmosdb.key` and manually creating CosmosDbConfig, this PR updates those files to apply TestRepositoryConfig and autowire the CosmosDbConfig.

In addition, RoleRepositoryCollectionIT is updated to add assertions.