### PR TITLE
Added prefixes to query parameters. Resolves issue #537.

### DIFF
--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/generator/AbstractQueryGenerator.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/generator/AbstractQueryGenerator.java
@@ -66,8 +66,8 @@ public abstract class AbstractQueryGenerator {
         final String subject = criteria.getSubject();
         final Object value1 = toCosmosDbValue(criteria.getSubjectValues().get(0));
         final Object value2 = toCosmosDbValue(criteria.getSubjectValues().get(1));
-        final String subject1 = "start";
-        final String subject2 = "end";
+        final String subject1 = subject + "start";
+        final String subject2 = subject + "end";
         final String parameter1 = generateQueryParameter(subject1);
         final String parameter2 = generateQueryParameter(subject2);
         final String keyword = criteria.getType().getSqlKeyword();


### PR DESCRIPTION
Fix: added prefixes to query parameters names generated for CriteriaType.BETWEEN. Parameters names should be unique, otherwise CosmosClientException is thrown with error: "Invalid query. Specified duplicate parameter name '@start'."

Addresses this issue : https://github.com/microsoft/spring-data-cosmosdb/issues/537