### PR TITLE
 Delete respects etag

### DIFF
--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/CosmosOperations.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/CosmosOperations.java
@@ -62,6 +62,8 @@ public interface CosmosOperations {
 
     void deleteById(String containerName, Object id, PartitionKey partitionKey);
 
+    void deleteEntityById(String containerName, Object entity, Object id, PartitionKey partitionKey);
+
     void deleteAll(String containerName, Class<?> domainType);
 
     /**

--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleCosmosRepository.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/repository/support/SimpleCosmosRepository.java
@@ -198,7 +198,8 @@ public class SimpleCosmosRepository<T, ID extends Serializable> implements Cosmo
 
         final String partitionKeyValue = information.getPartitionKeyFieldValue(entity);
 
-        operation.deleteById(information.getContainerName(),
+        operation.deleteEntityById(information.getContainerName(),
+                entity,
                 information.getId(entity),
                 partitionKeyValue == null ? null : new PartitionKey(partitionKeyValue));
     }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/EtagIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/EtagIT.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for
+ * license information.
+ */
+package com.microsoft.azure.spring.data.cosmosdb.repository.integration;
+
+import com.microsoft.azure.spring.data.cosmosdb.domain.Person;
+import com.microsoft.azure.spring.data.cosmosdb.exception.CosmosDBAccessException;
+import com.microsoft.azure.spring.data.cosmosdb.repository.TestRepositoryConfig;
+import com.microsoft.azure.spring.data.cosmosdb.repository.repository.PersonRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.ADDRESSES;
+import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.FIRST_NAME;
+import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.HOBBIES;
+import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.ID_1;
+import static com.microsoft.azure.spring.data.cosmosdb.common.TestConstants.LAST_NAME;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestRepositoryConfig.class)
+public class EtagIT {
+
+    @Autowired
+    PersonRepository personRepository;
+
+    @After
+    public void cleanup() {
+        personRepository.deleteAll();
+    }
+
+    private static Person createPerson() {
+        return new Person(UUID.randomUUID().toString(), FIRST_NAME, LAST_NAME, HOBBIES, ADDRESSES);
+    }
+
+    @Test
+    public void testCrudOperationsShouldApplyEtag() {
+        final Person insertedPerson = personRepository.save(createPerson());
+        Assert.assertNotNull(insertedPerson.get_etag());
+
+        insertedPerson.setFirstName(LAST_NAME);
+        final Person updatedPerson = personRepository.save(insertedPerson);
+        Assert.assertNotNull(updatedPerson.get_etag());
+        Assert.assertNotEquals(insertedPerson.get_etag(), updatedPerson.get_etag());
+
+        final Optional<Person> foundPerson = personRepository.findById(insertedPerson.getId());
+        Assert.assertTrue(foundPerson.isPresent());
+        Assert.assertNotNull(foundPerson.get().get_etag());
+        Assert.assertEquals(updatedPerson.get_etag(), foundPerson.get().get_etag());
+    }
+
+    @Test
+    public void testCrudListOperationsShouldApplyEtag() {
+        final List<Person> people = new ArrayList<>();
+        people.add(createPerson());
+        people.add(createPerson());
+
+        final List<Person> insertedPeople = toList(personRepository.saveAll(people));
+        insertedPeople.forEach(person -> Assert.assertNotNull(person.get_etag()));
+
+        insertedPeople.forEach(person -> person.setFirstName(LAST_NAME));
+        final List<Person> updatedPeople = toList(personRepository.saveAll(insertedPeople));
+        for (int i = 0; i < updatedPeople.size(); i++) {
+            final Person insertedPerson = insertedPeople.get(i);
+            final Person updatedPerson = updatedPeople.get(i);
+            Assert.assertEquals(insertedPerson.getId(), updatedPerson.getId());
+            Assert.assertNotNull(updatedPerson.get_etag());
+            Assert.assertNotEquals(insertedPerson.get_etag(), updatedPerson.get_etag());
+        }
+
+        final List<String> peopleIds = updatedPeople.stream()
+                .map(Person::getId)
+                .collect(Collectors.toList());
+        final List<Person> foundPeople = toList(personRepository.findAllById(peopleIds));
+        for (int i = 0; i < foundPeople.size(); i++) {
+            final Person updatedPerson = updatedPeople.get(i);
+            final Person foundPerson = foundPeople.get(i);
+            Assert.assertNotNull(foundPerson.get_etag());
+            Assert.assertEquals(updatedPerson.get_etag(), foundPerson.get_etag());
+        }
+    }
+
+    private List<Person> toList(Iterable<Person> people) {
+        return StreamSupport.stream(people.spliterator(), false)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testShouldFailIfEtagDoesNotMatch() {
+        final Person insertedPerson = personRepository.save(createPerson());
+        insertedPerson.setFirstName(LAST_NAME);
+
+        final Person updatedPerson = personRepository.save(insertedPerson);
+        updatedPerson.set_etag(insertedPerson.get_etag());
+
+        try {
+            personRepository.save(updatedPerson);
+            Assert.fail();
+        } catch (CosmosDBAccessException ex) {
+        }
+
+        try {
+            personRepository.delete(updatedPerson);
+            Assert.fail();
+        } catch (CosmosDBAccessException ex) {
+        }
+    }
+
+}


### PR DESCRIPTION
@kushagraThapar 

SimpleCosmosRepository:delete should respect the etag value if the input object is versioned.

I would like to get your thoughts on something else related to @Version but not addressed in this PR.  Currently, there is a strict dependency on the specific name of the @Version field - it must be "_etag".  IMO, this is problematic for two reasons. 
 First, this seems like an implementation detail of Cosmos and not something that necessarily needs to be exposed at the bean level.  Second, some companies have naming standards that disallow underscores in variable names.  

More importantly, as currently implemented, someone could annotate a field that is named something other than "_etag" with @Version and the library will allow it, it just won't actually do optimistic locking.  This could be fixed by looking for @Version and disallowing it on fields not named "_etag" but I would rather the library transparently handle converting the field annotated with @Version to/from the property "_etag" when sending/receiving.  The problem is that to do it cleanly would require minor (but breaking) changes to the CosmosOperations class.  Let me know if this is something that you would be interested in and I'll throw up another PR outlining the approach.