### PR TITLE
CosmosException when using azure-spring-data-cosmos query methods with repeated parameters

### DIFF
--- a/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/generator/AbstractQueryGenerator.java
+++ b/src/main/java/com/microsoft/azure/spring/data/cosmosdb/core/generator/AbstractQueryGenerator.java
@@ -22,6 +22,7 @@ import org.springframework.util.StringUtils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.microsoft.azure.spring.data.cosmosdb.core.convert.MappingCosmosConverter.toCosmosDbValue;
@@ -30,7 +31,8 @@ import static com.microsoft.azure.spring.data.cosmosdb.core.convert.MappingCosmo
 public abstract class AbstractQueryGenerator {
 
     private String generateQueryParameter(@NonNull String subject) {
-        return subject.replaceAll("\\.", "_"); // user.name is not valid sql parameter identifier.
+        // user.name is not valid sql parameter identifier.
+        return subject.replaceAll("\\.", "_") + UUID.randomUUID().toString().replaceAll("-", "_");
     }
 
     private String generateUnaryQuery(@NonNull Criteria criteria) {

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositoryIT.java
@@ -160,6 +160,13 @@ public class ProjectRepositoryIT {
 
         assertProjectListEquals(projects, Arrays.asList(PROJECT_0, PROJECT_4));
     }
+    
+    @Test
+    public void testFindByWithRepeatedParameters() {
+        List<Project> projects = this.repository.findByNameAndCreatorOrNameAndCreator(NAME_1, CREATOR_1, NAME_2, CREATOR_2);
+
+        assertProjectListEquals(projects, Arrays.asList(PROJECT_1, PROJECT_2));
+    }
 
     @Test
     public void testFindByWithOrPartition() {

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ProjectRepositoryIT.java
@@ -163,7 +163,8 @@ public class ProjectRepositoryIT {
     
     @Test
     public void testFindByWithRepeatedParameters() {
-        List<Project> projects = this.repository.findByNameAndCreatorOrNameAndCreator(NAME_1, CREATOR_1, NAME_2, CREATOR_2);
+        final List<Project> projects = 
+            this.repository.findByNameAndCreatorOrNameAndCreator(NAME_1, CREATOR_1, NAME_2, CREATOR_2);
 
         assertProjectListEquals(projects, Arrays.asList(PROJECT_1, PROJECT_2));
     }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ReactiveCourseRepositoryIT.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/integration/ReactiveCourseRepositoryIT.java
@@ -260,4 +260,12 @@ public class ReactiveCourseRepositoryIT {
                     })
                     .verifyComplete();
     }
+    
+    @Test
+    public void testFindByNameAndDepartmentOrNameAndDepartment() {
+        final Flux<Course> findResult = repository.findByNameAndDepartmentOrNameAndDepartment(
+            COURSE_NAME_1, DEPARTMENT_NAME_3, COURSE_NAME_2, DEPARTMENT_NAME_2);
+        StepVerifier.create(findResult).expectNext(COURSE_1, COURSE_2).verifyComplete();
+    }
+
 }

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ProjectRepository.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ProjectRepository.java
@@ -21,6 +21,8 @@ public interface ProjectRepository extends CosmosRepository<Project, String> {
     List<Project> findByNameOrForkCount(String name, Long forkCount);
 
     List<Project> findByNameAndCreator(String name, String creator);
+    
+    List<Project> findByNameAndCreatorOrNameAndCreator(String name, String creator, String name2, String creator2);
 
     List<Project> findByNameOrCreator(String name, String creator);
 

--- a/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ReactiveCourseRepository.java
+++ b/src/test/java/com/microsoft/azure/spring/data/cosmosdb/repository/repository/ReactiveCourseRepository.java
@@ -14,4 +14,16 @@ import java.util.Collection;
 public interface ReactiveCourseRepository extends ReactiveCosmosRepository<Course, String> {
 
     Flux<Course> findByDepartmentIn(Collection<String> departments);
+    
+    /**
+     * Find Course list by (name and department) or (name2 and department2)
+     * @param name name
+     * @param department department
+     * @param name2 name2
+     * @param department2 department2
+     * @return Course list
+     */
+    Flux<Course> findByNameAndDepartmentOrNameAndDepartment(String name,
+        String department, String name2, String department2);
+
 }


### PR DESCRIPTION
Backporting the [PR](https://github.com/Azure/azure-sdk-for-java/pull/17962) that solved the [same issue](https://github.com/Azure/azure-sdk-for-java/issues/17961) for the azure-spring-data-cosmos library.